### PR TITLE
TASK: Make compatible with logger changes in 4.0 and 5.0

### DIFF
--- a/Classes/Notifier.php
+++ b/Classes/Notifier.php
@@ -6,7 +6,7 @@ namespace CodeQ\PublishNotifier;
 
 use Maknz\Slack\Client;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Log\SystemLoggerInterface;
+use Psr\Log\LoggerInterface;
 use Neos\Flow\Configuration\Exception\InvalidConfigurationException;
 use Neos\SwiftMailer\Message;
 use Neos\ContentRepository\Domain\Model\Workspace;
@@ -18,7 +18,7 @@ class Notifier
 {
     /**
      * @Flow\Inject
-     * @var SystemLoggerInterface
+     * @var LoggerInterface
      */
     protected $systemLogger;
 

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,9 @@
     "name": "codeq/publishnotifier",
     "license": "GPL-3.0+",
     "require": {
-        "neos/neos": "~3.2 || ~4.0 || ~5.0 || dev-master",
+        "neos/neos": "~4.0 || ~5.0 || dev-master",
         "neos/swiftmailer": "*",
+        "psr/log": "^1.0",
         "maknz/slack": "~1.7.0"
     },
     "autoload": {


### PR DESCRIPTION
The PSR logger was introduced  in Neos 4.0 and the old
logger removed with 5.0, therefore this change is needed to
make the package work with Neos 5.0 and above.